### PR TITLE
fix Bad Smells in chrisliebaer.chrisliebot.abstraction.LimiterConfig

### DIFF
--- a/src/main/java/chrisliebaer/chrisliebot/abstraction/LimiterConfig.java
+++ b/src/main/java/chrisliebaer/chrisliebot/abstraction/LimiterConfig.java
@@ -117,7 +117,7 @@ public class LimiterConfig {
 					}
 					
 					// commit current string buffer to output
-					out.add(prefix + sb.toString());
+					out.add(prefix + sb);
 					sb.setLength(0);
 				} else {
 					// append current string to string builder
@@ -130,7 +130,7 @@ public class LimiterConfig {
 			
 			// append pending string builer, if not empty
 			if (sb.length() != 0)
-				out.add(prefix + sb.toString());
+				out.add(prefix + sb);
 		}
 		
 		// we need to check if the output exceeds our limits and take appropriate action


### PR DESCRIPTION
# Repairing Code Style Issues
## UnnecessaryToStringCall
<!--laughing-train-refactor -->
The `toString()` method is not needed in cases the underlying method handles the conversion.
## Changes: 
* Removed unnecessary `toString()` call in `sb.toString()`
<!-- ruleID: "UnnecessaryToStringCall"
filePath: "src/main/java/chrisliebaer/chrisliebot/abstraction/LimiterConfig.java"
position:
  startLine: 120
  endLine: 0
  startColumn: 26
  endColumn: 0
  charOffset: 4619
  charLength: 8
message: "Unnecessary 'toString()' call"
messageMarkdown: "Unnecessary `toString()` call"
snippet: "\t\t\t\t\t\n\t\t\t\t\t// commit current string buffer to output\n\t\t\t\t\
  \tout.add(prefix + sb.toString());\n\t\t\t\t\tsb.setLength(0);\n\t\t\t\t} else {"
analyzer: "Qodana"
 -->
<!-- fingerprint:-1294015314 -->
* Removed unnecessary `toString()` call in `sb.toString()`
<!-- ruleID: "UnnecessaryToStringCall"
filePath: "src/main/java/chrisliebaer/chrisliebot/abstraction/LimiterConfig.java"
position:
  startLine: 133
  endLine: 0
  startColumn: 25
  endColumn: 0
  charOffset: 4921
  charLength: 8
message: "Unnecessary 'toString()' call"
messageMarkdown: "Unnecessary `toString()` call"
snippet: "\t\t\t// append pending string builer, if not empty\n\t\t\tif (sb.length()\
  \ != 0)\n\t\t\t\tout.add(prefix + sb.toString());\n\t\t}\n\t\t"
analyzer: "Qodana"
 -->
<!-- fingerprint:1091226694 -->
