### PR TITLE
fix Bad Smells in chrisliebaer.chrisliebot.command.discord.ExplainCommand

### DIFF
--- a/src/main/java/chrisliebaer/chrisliebot/command/discord/ExplainCommand.java
+++ b/src/main/java/chrisliebaer/chrisliebot/command/discord/ExplainCommand.java
@@ -118,7 +118,6 @@ public class ExplainCommand implements ChrislieListener.Command {
 		} else {
 			ErrorOutputBuilder.generic("Ich konnte diese Nachricht leider nicht finden. Sie wurde entweder gelöscht oder du bist nicht berechtigt" +
 					" Informationen über diese Nachricht abzufragen.").write(invc).send();
-			return;
 		}
 	}
 }


### PR DESCRIPTION
# Repairing Code Style Issues
## Unnecessary Return
`return` is unnecessary as the last statement in a `void` method
## Changes: 
* `return` is unnecessary as the last statement in a 'void' method
<!-- ruleID: "UnnecessaryReturn"
filePath: "src/main/java/chrisliebaer/chrisliebot/command/discord/ExplainCommand.java"
position:
  startLine: 121
  endLine: 0
  startColumn: 4
  endColumn: 0
  charOffset: 5615
  charLength: 6
message: "'return' is unnecessary as the last statement in a 'void' method"
messageMarkdown: "`return` is unnecessary as the last statement in a 'void' method"
snippet: "\t\t\tErrorOutputBuilder.generic(\"Ich konnte diese Nachricht leider nicht\
  \ finden. Sie wurde entweder gelöscht oder du bist nicht berechtigt\" +\n\t\t\t\t\
  \t\" Informationen über diese Nachricht abzufragen.\").write(invc).send();\n\t\t\
  \treturn;\n\t\t}\n\t}"
analyzer: "Qodana"
 -->
<!-- fingerprint:472512733 -->
