### PR TITLE
fix Bad Smells in chrisliebaer.chrisliebot.command.string.FlipCommand

### DIFF
--- a/src/main/java/chrisliebaer/chrisliebot/command/string/FlipCommand.java
+++ b/src/main/java/chrisliebaer/chrisliebot/command/string/FlipCommand.java
@@ -36,7 +36,7 @@ public class FlipCommand implements ChrislieListener.Command {
 			else
 				sb.append(LOOKUP_FLIP.charAt(idx));
 		}
-		invc.reply("(╯°□°）╯ " + sb.reverse().toString());
+		invc.reply("(╯°□°）╯ " + sb.reverse());
 	}
 	
 	@Override


### PR DESCRIPTION
# Repairing Code Style Issues
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion.
## Changes: 
* Removed unnecessary `toString()` call in `sb.reverse().toString()`
<!-- ruleID: "UnnecessaryToStringCall"
filePath: "src/main/java/chrisliebaer/chrisliebot/command/string/FlipCommand.java"
position:
  startLine: 39
  endLine: 0
  startColumn: 40
  endColumn: 0
  charOffset: 1135
  charLength: 8
message: "Unnecessary 'toString()' call"
messageMarkdown: "Unnecessary `toString()` call"
snippet: "\t\t\t\tsb.append(LOOKUP_FLIP.charAt(idx));\n\t\t}\n\t\tinvc.reply(\"(╯°\
  □°）╯ \" + sb.reverse().toString());\n\t}\n\t"
analyzer: "Qodana"
 -->
<!-- fingerprint:-496422673 -->
