### PR TITLE
fix Bad Smells in chrisliebaer.chrisliebot.util.OutOfBandTransmission

### DIFF
--- a/src/main/java/chrisliebaer/chrisliebot/util/OutOfBandTransmission.java
+++ b/src/main/java/chrisliebaer/chrisliebot/util/OutOfBandTransmission.java
@@ -14,12 +14,12 @@ public class OutOfBandTransmission {
 	private static final String FILE_EXTENSION = ".txt";
 	private static final Charset CHARSET = StandardCharsets.UTF_8;
 	
-	private @NotBlank String generator;
-	private @NotBlank String path;
+	 @NotBlankprivate String generator;
+	 @NotBlankprivate String path;
 	
 	public String send(String content) throws IOException {
 		var uuid = UUID.randomUUID();
-		var file = new File(path, uuid.toString() + ".txt");
+		var file = new File(path, uuid + ".txt");
 		FileUtils.writeStringToFile(file, content, StandardCharsets.UTF_8);
 		return generator.replace("${file}", file.getName());
 	}

--- a/src/main/java/chrisliebaer/chrisliebot/util/OutOfBandTransmission.java
+++ b/src/main/java/chrisliebaer/chrisliebot/util/OutOfBandTransmission.java
@@ -14,8 +14,8 @@ public class OutOfBandTransmission {
 	private static final String FILE_EXTENSION = ".txt";
 	private static final Charset CHARSET = StandardCharsets.UTF_8;
 	
-	 @NotBlankprivate String generator;
-	 @NotBlankprivate String path;
+	private @NotBlank String generator;
+	private @NotBlank String path;
 	
 	public String send(String content) throws IOException {
 		var uuid = UUID.randomUUID();


### PR DESCRIPTION
# Repairing Code Style Issues
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion.
## Changes: 
* Removed unnecessary `toString()` call in `uuid.toString()`
* 
<!-- laughing-train-refactor -->
<!-- ruleID: "UnnecessaryToStringCall"
filePath: "src/main/java/chrisliebaer/chrisliebot/util/OutOfBandTransmission.java"
position:
  startLine: 22
  endLine: 0
  startColumn: 34
  endColumn: 0
  charOffset: 627
  charLength: 8
message: "Unnecessary 'toString()' call"
messageMarkdown: "Unnecessary `toString()` call"
snippet: "\tpublic String send(String content) throws IOException {\n\t\tvar uuid\
  \ = UUID.randomUUID();\n\t\tvar file = new File(path, uuid.toString() + \".txt\"\
  );\n\t\tFileUtils.writeStringToFile(file, content, StandardCharsets.UTF_8);\n\t\t\
  return generator.replace(\"${file}\", file.getName());"
analyzer: "Qodana"
 -->
<!-- fingerprint:1501201548 -->
